### PR TITLE
Custom 404 Page

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import MainLayout from '../components/mainlayout'
+
+export default function NotFound() {
+    return (
+        <MainLayout>
+            <div className='not-found-content'>
+                <h1 className='fade-in'>Woah there!</h1>
+                <p>Looks like you've taken a wrong turn.</p>
+                <p>No worries, just select a page up there to make it back.</p>
+            </div>
+        </MainLayout>
+    )
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -65,6 +65,10 @@ div {
   height: $content-height;
 }
 
+.not-found-content {
+    display: block;
+}
+
 h1 {
   color: $secondary-color;
   font-size: 5em;


### PR DESCRIPTION
### Summary
In general, I *hate* when a 404 page doesn't give you a way to get back to valid pages.
This custom 404 page is wrapped in the same navbar as every other page, so you can always make it back.

If accepted, this PR will:
- Create a custom 404 page

### To Test
1. Run `yarn && yarn start`
1. Visit http://localhost:8000/
1. Click on a link
1. Add some random letters to the URL
1. Click "Preview Custom 404 Page"
1. Does the custom 404 page have the navbar wrapped around it?
1. Can you get back to a valid page from there?

### Suggested Reading
- [Adding a 404 Page](https://www.gatsbyjs.org/docs/add-404-page/#reach-skip-nav)
