### PR TITLE
Add rel='noreferrer' to anchor tags to stop warnings

### DIFF
--- a/src/components/contact/contactinfoitem.js
+++ b/src/components/contact/contactinfoitem.js
@@ -5,7 +5,12 @@ export default function ContactInfoItem({ icon, link, text }) {
     return (
         <Fragment>
             <FontAwesomeIcon className='icon' icon={icon} />
-            <a target='_blank' href={link} className='contact-info-item'>
+            <a
+                className='contact-info-item'
+                href={link}
+                target='_blank'
+                rel='noreferrer'
+            >
                 {text}
             </a>
             <div className='break'></div>


### PR DESCRIPTION
### Summary
This PR fixes #15 by adding `rel='noreferrer'` to the anchor tags. This is necessary specifically because I am using `target='_blank'` to open links in new tabs.

If accepted, this PR will:
- Stop the warning from happening when building and running my project

### To Test
1. Run `yarn && yarn start`
1. In the console, you should no longer see the warning about using noreferrer when using `target='_blank'`

### Suggested Reading
- [`noreferrer` Documentation](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer)
